### PR TITLE
Fixed typo in MDPI scraper

### DIFF
--- a/scrapers/mdpi.json
+++ b/scrapers/mdpi.json
@@ -60,7 +60,7 @@
       }
     },
     "fulltext_xml": {
-      "selector": "//meta[@name='fulltest_xml']",
+      "selector": "//meta[@name='fulltext_xml']",
       "attribute": "content",
       "download": {
         "rename": "fulltext.xml"


### PR DESCRIPTION
The typo meant that the fulltext XML was not extracted, as it was spelled "fulltest".
